### PR TITLE
Docker Compose for Python

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,1 +1,1 @@
-./bench
+bench

--- a/initial-data/.gitignore
+++ b/initial-data/.gitignore
@@ -1,2 +1,3 @@
 result/*
 !result/.gitkeep
+env

--- a/initial-data/Makefile
+++ b/initial-data/Makefile
@@ -20,7 +20,7 @@ estate_data: make_estate_data.py
 
 verification_data: ./make_verification_data
 	rm -rf ./result/verification_data
-	docker-compose -f ../webapp/docker-compose/go.yaml down -v
+	docker-compose -f ../webapp/docker-compose/go.yaml build
 	docker-compose -f ../webapp/docker-compose/go.yaml up -d mysql api-server
 	wayt http -u "http://localhost:1323/api/estate/search/condition"
 	curl -X POST "localhost:1323/initialize"

--- a/webapp/docker-compose/python.yaml
+++ b/webapp/docker-compose/python.yaml
@@ -1,0 +1,72 @@
+version: "3"
+services:
+  mysql:
+    image: mysql:5.7
+    volumes:
+      - ../mysql/data:/var/lib/mysql
+      - ../mysql/db:/docker-entrypoint-initdb.d
+      - ../logs/mysql:/var/log/mysql
+      - ../../provisioning/ansible/roles/web-bootstrap/files/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ../../provisioning/ansible/roles/web-bootstrap/files/slow-mysqld.cnf:/etc/mysql/conf.d/slowquery.cnf
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: isuumo
+      MYSQL_USER: isucon
+      MYSQL_PASSWORD: isucon
+    ports:
+      - "3306:3306"
+
+  api-server:
+    build: ../python
+    entrypoint:
+      - dockerize
+      - -timeout
+      - 60s
+      - -wait
+      - tcp://mysql:3306
+    volumes:
+      - ../mysql/db:/mysql/db
+      - ../fixture:/fixture
+    environment:
+      MYSQL_DBNAME: isuumo
+      MYSQL_USER: isucon
+      MYSQL_PASS: isucon
+      MYSQL_HOST: mysql
+      SERVER_PORT: 1323
+    ports:
+      - "1323:1323"
+    depends_on:
+      - mysql
+    command: python app.py
+
+  frontend:
+    build: ../frontend
+    volumes:
+      - ../nginx/out:/frontend/out
+
+  nginx:
+    build: ../nginx
+    volumes:
+        - ../../provisioning/ansible/roles/web-bootstrap/files/nginx.conf.template:/etc/nginx/nginx.conf.template
+        - ../logs/nginx:/var/log/nginx
+        - ../nginx/conf.d:/etc/nginx/conf.d
+        - ../nginx/out:/www/data
+    ports:
+      - "8080:80"
+    entrypoint:
+      - dockerize
+      - -timeout
+      - 60s
+      - -wait
+      - http://api-server:1323/api/estate/search/condition
+    environment:
+      API_SERVER: api-server
+    depends_on:
+      - frontend
+    command: >
+      /bin/sh -c
+      "envsubst '
+      $$API_SERVER
+      '< /etc/nginx/nginx.conf.template
+      > /etc/nginx/nginx.conf
+      && nginx -g 'daemon off;'"


### PR DESCRIPTION
- Python環境のdocker-compose.yamlが存在しなかったため追加
- `initial-data`内部のMakefileを修正
- .gitignoreを修正