### PR TITLE
Restrict resources

### DIFF
--- a/initial-data/Makefile
+++ b/initial-data/Makefile
@@ -20,8 +20,8 @@ estate_data: make_estate_data.py
 
 verification_data: ./make_verification_data
 	rm -rf ./result/verification_data
-	docker-compose -f ../webapp/docker-compose/go.yaml build
-	docker-compose -f ../webapp/docker-compose/go.yaml up -d mysql api-server
+	docker-compose -f ../webapp/docker-compose/go.yaml down -v
+	docker-compose -f ../webapp/docker-compose/go.yaml up --build -d mysql api-server
 	wayt http -u "http://localhost:1323/api/estate/search/condition"
 	curl -X POST "localhost:1323/initialize"
 	go build -o ./make_verification_data/main ./make_verification_data/*.go

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -1,9 +1,9 @@
 SHELL=/bin/bash
 api-server/%: ## api-server/${lang}docker-compose up with mysql and api-server 
 	docker-compose -f docker-compose/$(shell basename $@).yaml down -v
-	docker-compose -f docker-compose/$(shell basename $@).yaml up --build mysql api-server
+	docker-compose -f docker-compose/$(shell basename $@).yaml up --build mysql api-server --compatibility
 
 isuumo/%: ## isuumo/${lang} docker-compose up with mysql and api-server frontend nginx
 	docker-compose -f docker-compose/$(shell basename $@).yaml down -v
-	docker-compose -f docker-compose/$(shell basename $@).yaml up --build mysql api-server nginx frontend
+	docker-compose -f docker-compose/$(shell basename $@).yaml up --build mysql api-server nginx frontend --compatibility
 

--- a/webapp/docker-compose/python.yaml
+++ b/webapp/docker-compose/python.yaml
@@ -15,6 +15,14 @@ services:
       MYSQL_PASSWORD: isucon
     ports:
       - "3306:3306"
+    deploy:
+      resources:
+        limits:
+          cpus: 1
+          memory: 2048M
+        reservations:
+          cpus: 1
+          memory: 128M
 
   api-server:
     build: ../python
@@ -38,6 +46,14 @@ services:
     depends_on:
       - mysql
     command: python app.py
+    deploy:
+      resources:
+        limits:
+          cpus: 1
+          memory: 2048M
+        reservations:
+          cpus: 1
+          memory: 128M
 
   frontend:
     build: ../frontend


### PR DESCRIPTION
## 目的
- api-server, mysqlコンテナのリソース制限
- `initial-data`内部のdocker-composeコマンド改修

## 解決方法
- リソース制限をするコンテナ定義にdeployを追記(docker-compose/python.yamlのみ)

## 動作確認
- [ ] (動作確認の方法、確認ができたらチェックボックスを埋める)

## 参考文献 (Optional)
- (参考にした記事などのURLを貼る)
